### PR TITLE
Added normalized provider

### DIFF
--- a/iiif/descriptive.d.ts
+++ b/iiif/descriptive.d.ts
@@ -188,7 +188,7 @@ export declare type DescriptiveNormalized = OmitProperties<
   thumbnail: Array<Reference<'ContentResource'>>;
   placeholderCanvas: Reference<'Canvas'> | null;
   accompanyingCanvas: Reference<'Canvas'> | null;
-  provider: Array<ResourceProviderNormalized>;
+  provider: Array<Reference<'Agent'>>;
 
   /**
    * @deprecated since 3.0-beta - use placeholderCanvas or accompanyingCanvas


### PR DESCRIPTION
Proposes that when the [Parser](https://github.com/IIIF-Commons/parser) normalizes the provider, it will look like:
```
{
  provider: [
     { id: 'https://example.org/provider', type: 'Provider' }
  ]
}
```
instead of being inlined. 