### PR TITLE
Add maxWidth, maxHeight and maxArea to ImageService3 and ImageService

### DIFF
--- a/services/image-service.d.ts
+++ b/services/image-service.d.ts
@@ -80,6 +80,9 @@ export interface ImageService3 {
   protocol?: string;
   width?: number | null;
   height?: number | null;
+  maxWidth?: number | null;
+  maxHeight?: number | null;
+  maxArea?: number | null;
   attribution?: string;
   sizes?: ImageSize[];
   tiles?: ImageTile[];
@@ -100,6 +103,9 @@ export interface ImageService {
   protocol?: string;
   width?: number | null;
   height?: number | null;
+  maxWidth?: number | null;
+  maxHeight?: number | null;
+  maxArea?: number | null;
   attribution?: string;
   sizes?: ImageSize[];
   tiles?: ImageTile[];


### PR DESCRIPTION
These fields from the [Image API 3.0 Technical Properties](https://iiif.io/api/image/3.0/#52-technical-properties) were previously missing from the `ImageService3` and `ImageService` types.
Given that the corresponding values in the Image API 2.1 `ImageProfile` type are available, I think it makes sense to include them in the v3 types as well.